### PR TITLE
feat(oci): Add rcc oci parent command structure (T002, T003)

### DIFF
--- a/cmd/oci.go
+++ b/cmd/oci.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"github.com/robocorp/rcc/settings"
+	"github.com/spf13/cobra"
+)
+
+var ociCmd = &cobra.Command{
+	Use:   "oci",
+	Short: "Group of OCI image building commands.",
+	Long: `Group of commands for building and managing OCI (Open Container Initiative) images.
+
+These commands allow you to package your robot automation, along with a resolved
+Holotree environment and the RCC runtime, into a self-contained container image
+that can be run without requiring Python or RCC to be installed on the target machine.
+
+Subcommands:
+  build       Build an OCI image from a robot
+  dockerfile  Generate a Dockerfile for external build pipelines`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		settings.CriticalEnvironmentSettingsCheck()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(ociCmd)
+}

--- a/specs/001-oci-image-build/tasks.md
+++ b/specs/001-oci-image-build/tasks.md
@@ -20,8 +20,8 @@
 *Goal: Initialize project structure and dependencies.*
 
 - [ ] T001 Add `github.com/google/go-containerregistry` dependency to `go.mod`
-- [ ] T002 Create `cmd/oci.go` with `ociCmd` struct and help text
-- [ ] T003 Register `ociCmd` in `cmd/oci.go` `init()` function (add to `rootCmd`)
+- [X] T002 Create `cmd/oci.go` with `ociCmd` struct and help text
+- [X] T003 Register `ociCmd` in `cmd/oci.go` `init()` function (add to `rootCmd`)
 - [ ] T004 Create `common/oci` directory
 
 ## Phase 2: Foundational


### PR DESCRIPTION
## Summary\n\n- Create `cmd/oci.go` with `ociCmd` Cobra command for OCI image building\n- Register `ociCmd` in `init()` as subcommand of `rootCmd`\n- Add descriptive help text explaining OCI image packaging functionality\n- Mark T002 and T003 as complete in `tasks.md`\n\n## Related Issue\n\nCloses #20\n\n## Test plan\n\n- [x] Build compiles successfully (`go build ./cmd/...`)\n- [x] `rcc oci --help` displays help text correctly\n- [x] `rcc oci` appears in main command tree\n- [x] All unit tests pass (`go test ./...`)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)