### PR TITLE
Update templates URL for automatic updates

### DIFF
--- a/assets/robocorp_settings.yaml
+++ b/assets/robocorp_settings.yaml
@@ -21,7 +21,7 @@ autoupdates:
   assistant: https://github.com/yorko-io/assistant/releases/
   workforce-agent: https://github.com/yorko-io/workforce-agent/releases/
   setup-utility: https://github.com/yorko-io/setup-utility/releases/
-  templates: https://github.com/joshyorko/robot-templates/releases/download/v1.0.0/templates.yaml
+  templates: https://github.com/joshyorko/robot-templates/releases/latest/download/templates.yaml
   rcc-index: https://github.com/joshyorko/rcc/releases/latest/download/index.json
 
 certificates:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,12 @@
 # rcc change log
+## v18.12.1 (date: 12.12.2025)
+
+### Fixes
+
+- fix: templates URL now uses `latest` release instead of hardcoded `v1.0.0`
+  - RCC will now automatically pull the latest templates when new versions are released
+  - previously, the URL pointed to a static v1.0.0 release which prevented template updates
+
 ## v18.12.0 (date: 09.12.2025)
 
 ### Breaking Changes


### PR DESCRIPTION
Change the templates URL to point to the latest release, allowing RCC to automatically pull the most recent templates instead of being locked to a static version.