### PR TITLE
Automatically trigger Homebrew cask update on release

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -33,3 +33,15 @@ jobs:
                               tag: '${{ steps.get_version.outputs.version }}'
                           }
                       });
+
+            - name: Trigger Homebrew Cask Update
+              uses: actions/github-script@v8.0.0
+              with:
+                  github-token: ${{ secrets.HOMEBREW_TOOLS_PAT }}
+                  script: |
+                      await github.rest.actions.createWorkflowDispatch({
+                          owner: context.repo.owner,
+                          repo: 'homebrew-tools',
+                          workflow_id: 'update-rcc.yml',
+                          ref: 'main'
+                      });


### PR DESCRIPTION
## Description
Adds automatic triggering of the homebrew-tools repository's update-rcc.yml workflow when a new RCC release is created.

## Changes
- Added a new step to the create-release-tag.yml workflow that dispatches the update-rcc.yml workflow in the homebrew-tools repository
- Uses the HOMEBREW_TOOLS_PAT secret for cross-repository workflow dispatch

## Testing
To test this change:
1. Ensure the HOMEBREW_TOOLS_PAT secret is configured in the repository settings
2. Run the create-release-tag workflow
3. Verify that both the rcc.yaml workflow and the homebrew-tools update-rcc.yml workflow are triggered

## Related
Closes #78

## Checklist
- [x] RCC releases trigger an automatic update to the Homebrew cask
- [x] Integration works with the existing create-release-tag.yml workflow  
- [ ] Documentation is updated to reflect the new automated process (if needed)

## Notes
This PR requires the HOMEBREW_TOOLS_PAT secret to be set up with appropriate permissions to dispatch workflows in the homebrew-tools repository.