### PR TITLE
Prevent zip path traversal during archive extraction

### DIFF
--- a/operations/initialize.go
+++ b/operations/initialize.go
@@ -168,7 +168,12 @@ func unpack(content []byte, directory string) error {
 		if entry.FileInfo().IsDir() {
 			continue
 		}
-		target := filepath.Join(directory, entry.Name)
+		target, err := zipEntryTarget(directory, entry.Name)
+		if err != nil {
+			common.Error("zip extract", err)
+			success = false
+			continue
+		}
 		todo := WriteTarget{
 			Source: entry,
 			Target: target,

--- a/operations/zipper.go
+++ b/operations/zipper.go
@@ -47,6 +47,18 @@ func slashed(text string) string {
 	return strings.Replace(text, backslash, slash, -1)
 }
 
+func zipEntryTarget(directory, entry string) (string, error) {
+	target := filepath.Join(directory, slashed(entry))
+	relative, err := filepath.Rel(directory, target)
+	if err != nil {
+		return "", err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid archive entry path: %q", entry)
+	}
+	return target, nil
+}
+
 func HololibZipShape(file *zip.File) error {
 	library := libraryPattern.MatchString(file.Name)
 	catalog := catalogPattern.MatchString(file.Name)
@@ -161,9 +173,13 @@ func (it *unzipper) Explode(workers int, directory string) error {
 		if entry.FileInfo().IsDir() {
 			continue
 		}
+		target, err := zipEntryTarget(directory, entry.Name)
+		if err != nil {
+			return err
+		}
 		todo <- &WriteTarget{
 			Source: entry,
-			Target: filepath.Join(directory, slashed(entry.Name)),
+			Target: target,
 		}
 	}
 
@@ -246,12 +262,15 @@ func (it *unzipper) Extract(directory string) error {
 		if entry.FileInfo().IsDir() {
 			continue
 		}
-		target := filepath.Join(directory, slashed(entry.Name)[limit:])
+		target, err := zipEntryTarget(directory, slashed(entry.Name)[limit:])
+		if err != nil {
+			return fmt.Errorf("Problem while extracting zip, reason: %v", err)
+		}
 		todo := WriteTarget{
 			Source: entry,
 			Target: target,
 		}
-		err := todo.execute()
+		err = todo.execute()
 		if err != nil {
 			return fmt.Errorf("Problem while extracting zip, reason: %v", err)
 		}

--- a/operations/zipper_test.go
+++ b/operations/zipper_test.go
@@ -18,3 +18,16 @@ func TestCanConvertSlashes(t *testing.T) {
 	must.Equal(3, len(wintestpath))
 	must.Equal(slashed(wintestpath), nixtestpath)
 }
+
+func TestZipEntryTargetAcceptsNestedPath(t *testing.T) {
+	must, _ := hamlet.Specifications(t)
+	target, err := zipEntryTarget("/tmp/destination", "repo/robot.yaml")
+	must.Equal(nil, err)
+	must.Equal("/tmp/destination/repo/robot.yaml", target)
+}
+
+func TestZipEntryTargetRejectsTraversalPath(t *testing.T) {
+	_, wont := hamlet.Specifications(t)
+	_, err := zipEntryTarget("/tmp/destination", "../../outside.txt")
+	wont.Equal(nil, err)
+}


### PR DESCRIPTION
### Motivation
- Close a Zip Slip vulnerability where ZIP entry names could escape the intended extraction directory and overwrite arbitrary files during unzip, template unpacking, hololib imports, and other archive ingestion paths. 
- Provide a minimal, centralized validation to ensure archive entries do not contain path traversal components that land outside the destination directory. 

### Description
- Add a `zipEntryTarget(directory, entry string) (string, error)` helper in `operations/zipper.go` that builds the candidate target path and rejects entries whose cleaned relative path begins with `..`.
- Use `zipEntryTarget` from the parallel extractor (`Explode`) and the single-threaded extractor (`Extract`) so all archive extraction flows validate containment before writing.
- Apply the same validation in template unpacking (`operations/initialize.go`) to cover embedded/template archive handling.
- Add unit tests in `operations/zipper_test.go` to verify accepting a normal nested path and rejecting a traversal path.

### Testing
- Ran `gofmt` on modified files using `gofmt -w` to ensure formatting was applied successfully.
- Added tests and attempted `GOARCH=amd64 CGO_ENABLED=0 go test ./operations -run 'TestCanConvertSlashes|TestZipEntryTarget'`, which failed in this environment due to missing generated assets referenced by `blobs/embedded.go` (setup failure), not due to the change itself.
- Committed the changes after local edits and ran the repository-level formatting and commit steps successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0751a4a934832ab9f3cbb6602e70d1)