### PR TITLE
security: harden release tag handling in release workflow

### DIFF
--- a/.github/workflows/rcc.yaml
+++ b/.github/workflows/rcc.yaml
@@ -186,28 +186,22 @@ jobs:
           PYEOF
 
           cat rcc-builds/index.json
-      - name: Delete existing release and tag if present
+      - name: Validate release tag
+        id: validate_tag
         env:
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
-          # Delete release if exists
-          if gh release view "$TAG" &>/dev/null; then
-            echo "Deleting existing release for $TAG..."
-            gh release delete "$TAG" --yes --cleanup-tag
-          else
-            echo "No existing release for $TAG"
+          TAG="$RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z]+)*$ ]]; then
+            echo "Invalid release tag: $TAG"
+            exit 1
           fi
-          # Also delete tag if it exists (GitHub taints tags used by published releases)
-          if git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
-            echo "Deleting existing tag $TAG..."
-            git push origin --delete "$TAG" || true
-          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Create Draft Release with Assets
         uses: softprops/action-gh-release@v2.3.2
         with:
           files: rcc-builds/*
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ steps.validate_tag.outputs.tag }}
           target_commitish: ${{ github.sha }}
           draft: true
           prerelease: false
@@ -215,8 +209,8 @@ jobs:
       - name: Publish Release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.validate_tag.outputs.tag }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
           echo "Publishing draft release $TAG..."
           gh release edit "$TAG" --draft=false
           echo "Release $TAG is now public"


### PR DESCRIPTION
### Motivation
- Fix a command-injection and privileged-destructive risk in the release job where an unvalidated `workflow_dispatch` tag was interpolated directly into shell code while `contents: write` credentials were available. 
- Avoid automatic deletion of existing releases/tags from inside the privileged release job to reduce blast radius and remove an avenue for accidental or malicious replacement.

### Description
- Replaced the unsafe deletion step with a `Validate release tag` step (`id: validate_tag`) that reads the tag via the `RELEASE_TAG` environment variable instead of inline GitHub expression interpolation. 
- Enforced an allowlist regex (`^v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z]+)*$`) and emit the validated tag to `GITHUB_OUTPUT` as `tag`. 
- Switched the draft creation `tag_name` and the publish step to use the validated output `steps.validate_tag.outputs.tag` and removed the automatic `gh release delete` / tag deletion logic. 
- Modified file: `.github/workflows/rcc.yaml` to implement the above changes.

### Testing
- Ran `git diff --check` to verify no formatting issues and it completed successfully. 
- Verified repository state with `git status --short` to confirm only `.github/workflows/rcc.yaml` was modified and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074bdbf20c832aa44065e724b0c53d)