### PR TITLE
fix: block template zip path traversal

### DIFF
--- a/operations/initialize.go
+++ b/operations/initialize.go
@@ -157,6 +157,11 @@ func updateTemplates() (err error) {
 
 func unpack(content []byte, directory string) error {
 	common.Debug("Initializing:")
+	base, err := filepath.Abs(directory)
+	if err != nil {
+		return err
+	}
+	base = filepath.Clean(base)
 	size := int64(len(content))
 	byter := bytes.NewReader(content)
 	reader, err := zip.NewReader(byter, size)
@@ -168,7 +173,12 @@ func unpack(content []byte, directory string) error {
 		if entry.FileInfo().IsDir() {
 			continue
 		}
-		target := filepath.Join(directory, entry.Name)
+		target, err := safeTemplateTarget(base, entry.Name)
+		if err != nil {
+			common.Debug("Ignoring unsafe template path %q, reason: %v", entry.Name, err)
+			success = false
+			continue
+		}
 		todo := WriteTarget{
 			Source: entry,
 			Target: target,
@@ -180,6 +190,19 @@ func unpack(content []byte, directory string) error {
 		return fmt.Errorf("Problems while initializing robot. Use --debug to see details.")
 	}
 	return nil
+}
+
+func safeTemplateTarget(base, name string) (string, error) {
+	target := filepath.Join(base, name)
+	cleaned := filepath.Clean(target)
+	relative, err := filepath.Rel(base, cleaned)
+	if err != nil {
+		return "", err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("target escapes destination: %s", name)
+	}
+	return cleaned, nil
 }
 
 func ListTemplatesWithDescription(internal bool) StringPairList {

--- a/operations/initialize_test.go
+++ b/operations/initialize_test.go
@@ -1,0 +1,27 @@
+package operations
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/joshyorko/rcc/hamlet"
+)
+
+func TestSafeTemplateTargetAcceptsNormalPath(t *testing.T) {
+	must, _ := hamlet.Specifications(t)
+
+	base := filepath.Join("tmp", "robot")
+	target, err := safeTemplateTarget(base, "folder/file.txt")
+
+	must.Nil(err)
+	must.Equal(filepath.Join(base, "folder", "file.txt"), target)
+}
+
+func TestSafeTemplateTargetRejectsTraversalPath(t *testing.T) {
+	_, wont := hamlet.Specifications(t)
+
+	base := filepath.Join("tmp", "robot")
+	_, err := safeTemplateTarget(base, "../outside.txt")
+
+	wont.Nil(err)
+}


### PR DESCRIPTION
### Motivation
- A Zip Slip path-traversal sink in template extraction allowed zip entries to be joined directly to the workarea and overwrite files outside the target directory.
- The change is a minimal remediation to ensure templates downloaded/installed cannot write outside the requested initialization directory without altering the update source or remote trust model.

### Description
- Harden `unpack` by computing an absolute, cleaned `base` for the destination and validating each zip entry before writing.
- Add `safeTemplateTarget(base, name)` which resolves, cleans, and uses `filepath.Rel` to detect and reject any paths that escape `base` via `..` or equivalent traversal.
- Update `unpack` to skip and log unsafe entries instead of creating/truncating files outside the destination, preserving existing error flow when any entry is rejected.
- Add unit tests in `operations/initialize_test.go` that assert acceptable in-tree paths are allowed and traversal paths are rejected.

### Testing
- Ran formatting with `gofmt -w operations/initialize.go operations/initialize_test.go` which completed successfully.
- Attempted `GOARCH=amd64 CGO_ENABLED=0 go test ./operations` but the test run failed in this environment due to missing generated assets (the build fails in `blobs/embedded.go` expecting `assets/*.py`), so the test suite could not be executed here.
- Added focused unit tests for `safeTemplateTarget` to cover both acceptance and rejection cases; these tests were added but could not be executed in the current environment because of the above build/setup issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074f4760f4832aa25d2e0a04311798)