### PR TITLE
Harden create-release-tag workflow against script injection

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -17,11 +17,17 @@ jobs:
               id: get_version
               run: |
                   VERSION=$(grep 'Version =' common/version.go | cut -d '`' -f 2)
+                  if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                      echo "Invalid version format: $VERSION"
+                      exit 1
+                  fi
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
                   echo "Detected version: $VERSION"
 
             - name: Trigger RCC Release Workflow
               uses: actions/github-script@v8.0.0
+              env:
+                  VERSION: ${{ steps.get_version.outputs.version }}
               with:
                   script: |
                       await github.rest.actions.createWorkflowDispatch({
@@ -30,7 +36,7 @@ jobs:
                           workflow_id: 'rcc.yaml',
                           ref: 'main',
                           inputs: {
-                              tag: '${{ steps.get_version.outputs.version }}'
+                              tag: process.env.VERSION
                           }
                       });
 


### PR DESCRIPTION
### Motivation
- A workflow step interpolated an unvalidated version string into a JavaScript literal used by `actions/github-script`, enabling JavaScript injection if `common/version.go` contained a crafted value. 
- The change prevents privileged workflow token abuse by ensuring only well-formed release tags are forwarded into the github-script context.

### Description
- Added strict validation in the `Read Version` step to enforce the `vMAJOR.MINOR.PATCH` pattern using the regex `^v[0-9]+\.[0-9]+\.[0-9]+$` and fail the job if the extracted version does not match. 
- Stopped embedding the step output directly into the JavaScript string and instead pass the version via an environment variable (`env: VERSION`) and read it as `process.env.VERSION` inside `actions/github-script`. 
- Changes are limited to `.github/workflows/create-release-tag.yml` and preserve the existing workflow behavior for valid version values.

### Testing
- Ran `git diff --check` which returned no issues. 
- Verified the working tree with `git status --short` to confirm the workflow file was updated. 
- Performed a local inspection of the updated workflow file to ensure the regex and environment passing are present and correctly referenced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a074ed82528832a9471b322299a21e3)