### PR TITLE
[codex] Security hardening batch

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -16,8 +16,14 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"path"
+	"strings"
+
 	"dagger/rcc-ci/internal/dagger"
 )
+
+const defaultRccVersion = "v18.17.3"
 
 type RccCi struct{}
 
@@ -42,6 +48,136 @@ func (m *RccCi) RunRobotTests(ctx context.Context, source *dagger.Directory) (st
 		WithExec([]string{"rcc", "holotree", "variables", "-r", "developer/toolkit.yaml"}).
 		WithExec([]string{"rcc", "run", "-r", "developer/toolkit.yaml", "-t", "robot"}).
 		Stdout(ctx)
+}
+
+// Build a Linux container with RCC installed and the source mounted at /src.
+func (m *RccCi) buildRccContainer(
+	source *dagger.Directory,
+	rccVersion string,
+) *dagger.Container {
+	if rccVersion == "" {
+		rccVersion = defaultRccVersion
+	}
+	rccURL := fmt.Sprintf("https://github.com/joshyorko/rcc/releases/download/%s/rcc-linux64", rccVersion)
+
+	return dag.
+		Container(dagger.ContainerOpts{Platform: dagger.Platform("linux/amd64")}).
+		From("python:3.11-slim").
+		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "install", "-y", "curl", "ca-certificates"}).
+		WithExec([]string{"curl", "-L", "-o", "/usr/local/bin/rcc", rccURL}).
+		WithExec([]string{"chmod", "+x", "/usr/local/bin/rcc"}).
+		WithMountedCache("/root/.robocorp", dag.CacheVolume("robocorp-home")).
+		WithEnvVariable("ROBOCORP_HOME", "/root/.robocorp").
+		WithMountedDirectory("/src", source).
+		WithWorkdir("/src")
+}
+
+// Run any RCC command and return stdout.
+func (m *RccCi) Rcc(
+	ctx context.Context,
+	// The RCC command, for example: "run -t ProcessLocal".
+	c string,
+	// +defaultPath="."
+	source *dagger.Directory,
+	// RCC release version to install in the container.
+	// +default="v18.17.3"
+	rccVersion string,
+) (string, error) {
+	args, err := splitCommand(c)
+	if err != nil {
+		return "", err
+	}
+
+	container := m.buildRccContainer(source, rccVersion)
+	return container.WithExec(append([]string{"rcc"}, args...)).Stdout(ctx)
+}
+
+// Run any RCC command and return an output directory from the container.
+func (m *RccCi) RccWithOutput(
+	ctx context.Context,
+	// The RCC command, for example: "run -t ProcessLocal".
+	c string,
+	// +defaultPath="."
+	source *dagger.Directory,
+	// Container path to return after the RCC command runs.
+	// +default="./output"
+	outputPath string,
+	// RCC release version to install in the container.
+	// +default="v18.17.3"
+	rccVersion string,
+) (*dagger.Directory, error) {
+	args, err := splitCommand(c)
+	if err != nil {
+		return nil, err
+	}
+
+	container := m.buildRccContainer(source, rccVersion)
+	result := container.WithExec(append([]string{"rcc"}, args...))
+	return result.Directory(containerOutputPath(outputPath)), nil
+}
+
+func containerOutputPath(outputPath string) string {
+	if outputPath == "" || outputPath == "." {
+		return "/src/output"
+	}
+	if strings.HasPrefix(outputPath, "/") {
+		return path.Clean(outputPath)
+	}
+	return path.Join("/src", outputPath)
+}
+
+func splitCommand(command string) ([]string, error) {
+	var args []string
+	var current strings.Builder
+	var quote rune
+	escaped := false
+
+	for _, r := range command {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+
+		if r == '\\' && quote != '\'' {
+			escaped = true
+			continue
+		}
+
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+			continue
+		}
+
+		switch r {
+		case '\'', '"':
+			quote = r
+		case ' ', '\t', '\n', '\r':
+			if current.Len() > 0 {
+				args = append(args, current.String())
+				current.Reset()
+			}
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if escaped {
+		current.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote in RCC command")
+	}
+	if current.Len() > 0 {
+		args = append(args, current.String())
+	}
+
+	return args, nil
 }
 
 // Returns lines that match a pattern in the files of the provided Directory

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -23,7 +23,7 @@ import (
 	"dagger/rcc-ci/internal/dagger"
 )
 
-const defaultRccVersion = "v18.17.3"
+const defaultRccVersion = "v18.17.4"
 
 type RccCi struct{}
 
@@ -81,7 +81,7 @@ func (m *RccCi) Rcc(
 	// +defaultPath="."
 	source *dagger.Directory,
 	// RCC release version to install in the container.
-	// +default="v18.17.3"
+	// +default="v18.17.4"
 	rccVersion string,
 ) (string, error) {
 	args, err := splitCommand(c)
@@ -104,7 +104,7 @@ func (m *RccCi) RccWithOutput(
 	// +default="./output"
 	outputPath string,
 	// RCC release version to install in the container.
-	// +default="v18.17.3"
+	// +default="v18.17.4"
 	rccVersion string,
 ) (*dagger.Directory, error) {
 	args, err := splitCommand(c)

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -23,7 +23,7 @@ import (
 	"dagger/rcc-ci/internal/dagger"
 )
 
-const defaultRccVersion = "v18.17.4"
+const defaultRccVersion = "v18.17.3"
 
 type RccCi struct{}
 
@@ -81,7 +81,7 @@ func (m *RccCi) Rcc(
 	// +defaultPath="."
 	source *dagger.Directory,
 	// RCC release version to install in the container.
-	// +default="v18.17.4"
+	// +default="v18.17.3"
 	rccVersion string,
 ) (string, error) {
 	args, err := splitCommand(c)
@@ -104,7 +104,7 @@ func (m *RccCi) RccWithOutput(
 	// +default="./output"
 	outputPath string,
 	// RCC release version to install in the container.
-	// +default="v18.17.4"
+	// +default="v18.17.3"
 	rccVersion string,
 ) (*dagger.Directory, error) {
 	args, err := splitCommand(c)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -25,7 +25,6 @@ The primary workflow for building, testing, and releasing RCC across multiple pl
 - **Push** to `main` branch
 - **Version tags** matching `v*` pattern
 - **Pull requests** to `main` branch
-- **Manual dispatch** with optional version input
 
 > Note: Changes to `.github/workflows/` and `.dagger/` directories are ignored.
 
@@ -33,7 +32,7 @@ The primary workflow for building, testing, and releasing RCC across multiple pl
 
 #### 1. Build (`build`)
 - **Runner:** `ubuntu-latest`
-- **Condition:** Only runs on version tag pushes or manual dispatch
+- **Condition:** Only runs on trusted version tag pushes
 - **Steps:**
   - Checkout code
   - Set up Go 1.25.7 and Python 3.10
@@ -42,7 +41,7 @@ The primary workflow for building, testing, and releasing RCC across multiple pl
   - Upload artifacts for Linux, Windows, and macOS
 
 #### 2. Robot Tests (`robot`)
-- **Matrix:** Kubernetes and Windows runners
+- **Matrix:** Ubuntu and Windows runners
 - **Steps:**
   - Set up development environment
   - Install dependencies
@@ -50,7 +49,7 @@ The primary workflow for building, testing, and releasing RCC across multiple pl
   - Upload test reports as artifacts
 
 #### 3. Release (`release`)
-- **Condition:** Runs after successful build and robot test jobs
+- **Condition:** Runs after successful tag-push build
 - **Steps:**
   - Download built RCC binaries
   - Generate `index.json` with version metadata
@@ -65,7 +64,7 @@ None explicitly required (uses GitHub token for releases).
 
 **Release Trigger Workflow**
 
-A manual workflow that extracts the version from source code and triggers the main release pipeline.
+A manual workflow that extracts the version from source code, validates it, and creates the release tag that starts the main release pipeline.
 
 ### Triggers
 - **Manual dispatch only** (`workflow_dispatch`)
@@ -73,16 +72,17 @@ A manual workflow that extracts the version from source code and triggers the ma
 ### How It Works
 1. Checks out the repository with full Git history
 2. Extracts version from `common/version.go`
-3. Triggers the `rcc.yaml` workflow with the extracted version
+3. Validates the version string
+4. Creates and pushes the matching `v*` release tag
+5. Dispatches the Homebrew cask update workflow
 
 ### Permissions
-- `contents: write` - For repository access
-- `actions: write` - For triggering other workflows
+- `contents: write` - For creating the release tag
 
 ### Usage
 1. Navigate to Actions > "Create Release Tag"
 2. Click "Run workflow"
-3. The workflow will read the version and trigger a release
+3. The workflow will read the version, create the tag, and the tag push will trigger a release
 
 ---
 
@@ -213,6 +213,7 @@ The recommended release process uses these workflows:
 ┌─────────────────────────┐
 │  Update version in      │
 │  common/version.go      │
+│  and docs/changelog.md  │
 └───────────┬─────────────┘
             │
             ▼
@@ -223,9 +224,9 @@ The recommended release process uses these workflows:
             │
             ▼
 ┌─────────────────────────┐
-│  rcc.yaml triggers      │
+│  Tag push triggers      │
+│  rcc.yaml release path  │
 │  - Build all platforms  │
-│  - Run robot tests      │
 │  - Create GitHub release│
 └─────────────────────────┘
 ```
@@ -236,8 +237,8 @@ The recommended release process uses these workflows:
 |-------------|---------|---------|
 | Go | 1.25.7 | rcc.yaml |
 | Python | 3.10 | rcc.yaml |
-| Invoke | latest | rcc.yaml |
-| Dagger | latest | dagger.yaml |
+| Invoke | 2.2.0 | rcc.yaml |
+| Dagger | v0.20.8 | dagger.yaml |
 
 
 
@@ -253,7 +254,8 @@ The recommended release process uses these workflows:
 
 ### Release not triggering
 - Verify version tag matches `v*` pattern
-- Check that `create-release-tag.yml` successfully triggered `rcc.yaml`
+- Check that `create-release-tag.yml` created and pushed the expected tag
+- Check that `rcc.yaml` started from the tag push
 
 ## Contributing
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -41,7 +41,7 @@ The primary workflow for building, testing, and releasing RCC across multiple pl
   - Upload artifacts for Linux, Windows, and macOS
 
 #### 2. Robot Tests (`robot`)
-- **Matrix:** Ubuntu and Windows runners
+- **Matrix:** Ubuntu, macOS, and Windows runners
 - **Steps:**
   - Set up development environment
   - Install dependencies

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -7,7 +7,6 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write
-            actions: write
         steps:
             - uses: actions/checkout@v6.0.0
               with:
@@ -21,24 +20,20 @@ jobs:
                       echo "Invalid version format: $VERSION"
                       exit 1
                   fi
-                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
                   echo "Detected version: $VERSION"
 
-            - name: Trigger RCC Release Workflow
-              uses: actions/github-script@v8.0.0
+            - name: Create Release Tag
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
-              with:
-                  script: |
-                      await github.rest.actions.createWorkflowDispatch({
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          workflow_id: 'rcc.yaml',
-                          ref: 'main',
-                          inputs: {
-                              tag: process.env.VERSION
-                          }
-                      });
+              run: |
+                  git fetch --tags --force
+                  if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
+                      echo "Release tag already exists: $VERSION"
+                      exit 1
+                  fi
+                  git tag "$VERSION"
+                  git push origin "refs/tags/$VERSION"
 
             - name: Trigger Homebrew Cask Update
               uses: actions/github-script@v8.0.0

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -17,11 +17,17 @@ jobs:
               id: get_version
               run: |
                   VERSION=$(grep 'Version =' common/version.go | cut -d '`' -f 2)
+                  if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                      echo "Invalid version format: $VERSION"
+                      exit 1
+                  fi
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
                   echo "Detected version: $VERSION"
 
             - name: Trigger RCC Release Workflow
               uses: actions/github-script@v8.0.0
+              env:
+                  VERSION: ${{ steps.get_version.outputs.version }}
               with:
                   script: |
                       await github.rest.actions.createWorkflowDispatch({
@@ -30,7 +36,7 @@ jobs:
                           workflow_id: 'rcc.yaml',
                           ref: 'main',
                           inputs: {
-                              tag: '${{ steps.get_version.outputs.version }}'
+                              tag: process.env.VERSION
                           }
                       });
 

--- a/.github/workflows/rcc.yaml
+++ b/.github/workflows/rcc.yaml
@@ -180,28 +180,22 @@ jobs:
           PYEOF
 
           cat rcc-builds/index.json
-      - name: Delete existing release and tag if present
+      - name: Validate release tag
+        id: validate_tag
         env:
-          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
-          TAG="${{ github.ref_name }}"
-          # Delete release if exists
-          if gh release view "$TAG" &>/dev/null; then
-            echo "Deleting existing release for $TAG..."
-            gh release delete "$TAG" --yes --cleanup-tag
-          else
-            echo "No existing release for $TAG"
+          TAG="$RELEASE_TAG"
+          if [[ ! "$TAG" =~ ^v[0-9]+(\.[0-9]+)*([-.][0-9A-Za-z]+)*$ ]]; then
+            echo "Invalid release tag: $TAG"
+            exit 1
           fi
-          # Also delete tag if it exists (GitHub taints tags used by published releases)
-          if git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
-            echo "Deleting existing tag $TAG..."
-            git push origin --delete "$TAG" || true
-          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Create Draft Release with Assets
         uses: softprops/action-gh-release@v2.3.2
         with:
           files: rcc-builds/*
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ steps.validate_tag.outputs.tag }}
           target_commitish: ${{ github.sha }}
           draft: true
           prerelease: false
@@ -209,8 +203,8 @@ jobs:
       - name: Publish Release
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.validate_tag.outputs.tag }}
         run: |
-          TAG="${{ github.ref_name }}"
           echo "Publishing draft release $TAG..."
           gh release edit "$TAG" --draft=false
           echo "Release $TAG is now public"

--- a/.github/workflows/rcc.yaml
+++ b/.github/workflows/rcc.yaml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
       # Checkout first so setup-go can locate go.mod/go.sum for caching
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd

--- a/.github/workflows/rcc.yaml
+++ b/.github/workflows/rcc.yaml
@@ -24,20 +24,20 @@ jobs:
   build:
     name: Build RCC
     runs-on: ubuntu-latest
-    # Build only as part of a release flow (tag push).
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Build only for trusted version tag pushes.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     steps:
       # Checkout first so setup-go can locate go.mod/go.sum for caching
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: "1.25.7"
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
       - name: Install invoke
-        run: python -m pip install invoke
+        run: python -m pip install invoke==2.2.0
       - name: Show commit info
         run: inv what
       - name: Debug Build Job
@@ -59,7 +59,7 @@ jobs:
           cp build/macosarm64/rcc rcc-builds/rcc-macosarm64
           cp build/macosarm64/rccremote rcc-builds/rccremote-macosarm64
       - name: Upload RCC Binaries
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: RCC-Binaries
           path: rcc-builds/
@@ -75,22 +75,22 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
     steps:
       # Checkout first so setup-go can locate go.mod/go.sum for caching
-      - uses: actions/checkout@v5
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: "1.25.7"
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
       - name: Install invoke
-        run: python -m pip install invoke
+        run: python -m pip install invoke==2.2.0
       - name: Setup Robot Environment
         run: inv robotsetup
       - name: Show commit info
         run: inv what
       - name: Run Robot Framework Tests
         run: inv robot
-      - uses: actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: success() || failure()
         with:
           name: ${{ matrix.os }}-test-reports
@@ -99,7 +99,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs:
       - build
     # Only run this job on tag pushes (e.g., refs/tags/v18.5.0)
@@ -114,14 +114,14 @@ jobs:
           echo "GitHub ref: ${{ github.ref }}"
           echo "GitHub event name: ${{ github.event_name }}"
           echo "Build job status: ${{ needs.build.result }}"
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Download Built RCC Binaries
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0
         with:
           name: RCC-Binaries
           path: rcc-builds/
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
       - name: Generate index.json
@@ -192,7 +192,7 @@ jobs:
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Create Draft Release with Assets
-        uses: softprops/action-gh-release@v2.3.2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
         with:
           files: rcc-builds/*
           tag_name: ${{ steps.validate_tag.outputs.tag }}

--- a/.github/workflows/rcc.yaml
+++ b/.github/workflows/rcc.yaml
@@ -1,11 +1,5 @@
 name: Rcc
 on:
-  workflow_dispatch: # Enables manual triggering
-    inputs:
-      tag:
-        description: "Tag name to release (e.g., v18.5.0)"
-        required: false
-        type: string
   push:
     branches:
       - main
@@ -30,8 +24,8 @@ jobs:
   build:
     name: Build RCC
     runs-on: ubuntu-latest
-    # Build only as part of a release flow (tag push or manual dispatch).
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+    # Build only as part of a release flow (tag push).
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       # Checkout first so setup-go can locate go.mod/go.sum for caching
       - uses: actions/checkout@v5
@@ -105,10 +99,10 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     needs:
       - build
-    # Only run this job on tag pushes (e.g., refs/tags/v18.5.0) or manual dispatch
+    # Only run this job on tag pushes (e.g., refs/tags/v18.5.0)
     # Robot tests run on push to main, so code is already validated before release
     # Grant only the permissions needed to publish a release
     permissions:
@@ -132,7 +126,7 @@ jobs:
           python-version: "3.10"
       - name: Generate index.json
         env:
-          VERSION: ${{ inputs.tag || github.ref_name }}
+          VERSION: ${{ github.ref_name }}
           REPO: ${{ github.repository }}
         run: |
           export DATE=$(date +"%d.%-m.%Y")
@@ -190,7 +184,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG="${{ github.ref_name }}"
           # Delete release if exists
           if gh release view "$TAG" &>/dev/null; then
             echo "Deleting existing release for $TAG..."
@@ -207,7 +201,7 @@ jobs:
         uses: softprops/action-gh-release@v2.3.2
         with:
           files: rcc-builds/*
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           target_commitish: ${{ github.sha }}
           draft: true
           prerelease: false
@@ -216,7 +210,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG="${{ github.ref_name }}"
           echo "Publishing draft release $TAG..."
           gh release edit "$TAG" --draft=false
           echo "Release $TAG is now public"

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "rcc-ci",
-  "engineVersion": "v0.19.7",
+  "engineVersion": "v0.20.8",
   "sdk": {
     "source": "go"
   },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,9 +1,25 @@
 # rcc change log
-## v18.17.4 (date: 26.02.2026)
+## v18.17.4 (date: 23.05.2026)
 
 ### Security
 
 - fix: raise TLS diagnostics head-check minimum protocol from SSLv3 to TLS 1.0 to address CodeQL insecure TLS alert while preserving legacy diagnostics reach
+- security: reject unsafe zip archive entries during general unzip, hololib import, and template unpacking paths
+  - prevents path traversal entries from escaping the requested destination directory
+  - adds regression coverage for malicious traversal entries and normal nested-file extraction
+- security: validate micromamba tar archive members before extraction
+  - rejects absolute paths, path traversal entries, symlinks, and hard links before `tar.extractall`
+  - uses a unique temporary extraction directory per downloaded archive
+- security: harden release workflows
+  - release builds and publishing now run from trusted `v*` tag pushes only
+  - release tags are validated before publishing assets
+  - removes release/tag deletion from the release job
+  - pins GitHub Actions dependencies and `invoke` in the RCC workflow
+
+### Developer Experience
+
+- add Dagger RCC runner helpers for containerized local RCC commands and output-directory collection
+- update the manual release-tag workflow so it validates `common/version.go`, creates the release tag, and lets the tag push trigger the RCC release workflow
 
 ## v18.17.3 (date: 26.02.2026)
 

--- a/operations/initialize.go
+++ b/operations/initialize.go
@@ -168,7 +168,12 @@ func unpack(content []byte, directory string) error {
 		if entry.FileInfo().IsDir() {
 			continue
 		}
-		target := filepath.Join(directory, entry.Name)
+		target, err := zipEntryTarget(directory, entry.Name)
+		if err != nil {
+			common.Error("zip extract", err)
+			success = false
+			continue
+		}
 		todo := WriteTarget{
 			Source: entry,
 			Target: target,

--- a/operations/initialize_test.go
+++ b/operations/initialize_test.go
@@ -1,0 +1,29 @@
+package operations
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/joshyorko/rcc/hamlet"
+)
+
+func TestZipEntryTargetAcceptsTemplatePath(t *testing.T) {
+	must, _ := hamlet.Specifications(t)
+
+	base := filepath.Join("tmp", "robot")
+	target, err := zipEntryTarget(base, "folder/file.txt")
+
+	must.Nil(err)
+	absolute, err := filepath.Abs(filepath.Join(base, "folder", "file.txt"))
+	must.Nil(err)
+	must.Equal(filepath.Clean(absolute), target)
+}
+
+func TestZipEntryTargetRejectsTemplateTraversalPath(t *testing.T) {
+	_, wont := hamlet.Specifications(t)
+
+	base := filepath.Join("tmp", "robot")
+	_, err := zipEntryTarget(base, "../outside.txt")
+
+	wont.Nil(err)
+}

--- a/operations/zipper.go
+++ b/operations/zipper.go
@@ -48,12 +48,23 @@ func slashed(text string) string {
 }
 
 func zipEntryTarget(directory, entry string) (string, error) {
-	target := filepath.Join(directory, slashed(entry))
-	relative, err := filepath.Rel(directory, target)
+	base, err := filepath.Abs(directory)
 	if err != nil {
 		return "", err
 	}
-	if relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+	base = filepath.Clean(base)
+
+	name := slashed(entry)
+	if filepath.IsAbs(name) || filepath.VolumeName(name) != "" {
+		return "", fmt.Errorf("invalid archive entry path: %q", entry)
+	}
+
+	target := filepath.Clean(filepath.Join(base, name))
+	relative, err := filepath.Rel(base, target)
+	if err != nil {
+		return "", err
+	}
+	if relative == "." || relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
 		return "", fmt.Errorf("invalid archive entry path: %q", entry)
 	}
 	return target, nil

--- a/operations/zipper.go
+++ b/operations/zipper.go
@@ -47,6 +47,18 @@ func slashed(text string) string {
 	return strings.Replace(text, backslash, slash, -1)
 }
 
+func zipEntryTarget(directory, entry string) (string, error) {
+	target := filepath.Join(directory, slashed(entry))
+	relative, err := filepath.Rel(directory, target)
+	if err != nil {
+		return "", err
+	}
+	if relative == ".." || strings.HasPrefix(relative, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid archive entry path: %q", entry)
+	}
+	return target, nil
+}
+
 func HololibZipShape(file *zip.File) error {
 	library := libraryPattern.MatchString(file.Name)
 	catalog := catalogPattern.MatchString(file.Name)
@@ -161,9 +173,13 @@ func (it *unzipper) Explode(workers int, directory string) error {
 		if entry.FileInfo().IsDir() {
 			continue
 		}
+		target, err := zipEntryTarget(directory, entry.Name)
+		if err != nil {
+			return err
+		}
 		todo <- &WriteTarget{
 			Source: entry,
-			Target: filepath.Join(directory, slashed(entry.Name)),
+			Target: target,
 		}
 	}
 
@@ -246,12 +262,15 @@ func (it *unzipper) Extract(directory string) error {
 		if entry.FileInfo().IsDir() {
 			continue
 		}
-		target := filepath.Join(directory, slashed(entry.Name)[limit:])
+		target, err := zipEntryTarget(directory, slashed(entry.Name)[limit:])
+		if err != nil {
+			return fmt.Errorf("Problem while extracting zip, reason: %v", err)
+		}
 		todo := WriteTarget{
 			Source: entry,
 			Target: target,
 		}
-		err := todo.execute()
+		err = todo.execute()
 		if err != nil {
 			return fmt.Errorf("Problem while extracting zip, reason: %v", err)
 		}

--- a/operations/zipper.go
+++ b/operations/zipper.go
@@ -273,10 +273,10 @@ func (it *unzipper) Extract(directory string) error {
 		if entry.FileInfo().IsDir() {
 			continue
 		}
-		target, err := zipEntryTarget(directory, slashed(entry.Name)[limit:])
-		if err != nil {
-			return fmt.Errorf("Problem while extracting zip, reason: %v", err)
-		}
+			target, err := zipEntryTarget(directory, slashed(entry.Name)[limit:])
+			if err != nil {
+				return fmt.Errorf("Problem while extracting zip, reason: %v", err)
+			}
 		todo := WriteTarget{
 			Source: entry,
 			Target: target,

--- a/operations/zipper_test.go
+++ b/operations/zipper_test.go
@@ -18,3 +18,16 @@ func TestCanConvertSlashes(t *testing.T) {
 	must.Equal(3, len(wintestpath))
 	must.Equal(slashed(wintestpath), nixtestpath)
 }
+
+func TestZipEntryTargetAcceptsNestedPath(t *testing.T) {
+	must, _ := hamlet.Specifications(t)
+	target, err := zipEntryTarget("/tmp/destination", "repo/robot.yaml")
+	must.Equal(nil, err)
+	must.Equal("/tmp/destination/repo/robot.yaml", target)
+}
+
+func TestZipEntryTargetRejectsTraversalPath(t *testing.T) {
+	_, wont := hamlet.Specifications(t)
+	_, err := zipEntryTarget("/tmp/destination", "../../outside.txt")
+	wont.Equal(nil, err)
+}

--- a/operations/zipper_test.go
+++ b/operations/zipper_test.go
@@ -1,6 +1,9 @@
 package operations
 
 import (
+	"archive/zip"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/joshyorko/rcc/hamlet"
@@ -11,6 +14,28 @@ const (
 	nixtestpath = `a/b`
 )
 
+func writeTestZip(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("unable to create zip: %v", err)
+	}
+	defer file.Close()
+	writer := zip.NewWriter(file)
+	for name, content := range entries {
+		entry, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("unable to create zip entry: %v", err)
+		}
+		if _, err = entry.Write([]byte(content)); err != nil {
+			t.Fatalf("unable to write zip entry: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("unable to close zip writer: %v", err)
+	}
+}
+
 func TestCanConvertSlashes(t *testing.T) {
 	must, wont := hamlet.Specifications(t)
 
@@ -19,15 +44,52 @@ func TestCanConvertSlashes(t *testing.T) {
 	must.Equal(slashed(wintestpath), nixtestpath)
 }
 
+func TestUnzipRejectsPathTraversal(t *testing.T) {
+	must, wont := hamlet.Specifications(t)
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "malicious.zip")
+	writeTestZip(t, zipPath, map[string]string{
+		"../../outside.txt": "owned",
+	})
+
+	dest := filepath.Join(tmpDir, "dest")
+	err := Unzip(dest, zipPath, true, true, false)
+	wont.Nil(err)
+	_, statErr := os.Stat(filepath.Join(tmpDir, "outside.txt"))
+	must.Equal(true, os.IsNotExist(statErr))
+}
+
+func TestUnzipExtractsRegularFile(t *testing.T) {
+	must, _ := hamlet.Specifications(t)
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "good.zip")
+	writeTestZip(t, zipPath, map[string]string{
+		"safe/file.txt": "ok",
+	})
+
+	dest := filepath.Join(tmpDir, "dest")
+	err := Unzip(dest, zipPath, true, true, false)
+	must.Equal(nil, err)
+	content, err := os.ReadFile(filepath.Join(dest, "safe", "file.txt"))
+	must.Equal(nil, err)
+	must.Equal("ok", string(content))
+}
+
 func TestZipEntryTargetAcceptsNestedPath(t *testing.T) {
 	must, _ := hamlet.Specifications(t)
-	target, err := zipEntryTarget("/tmp/destination", "repo/robot.yaml")
+	base := t.TempDir()
+
+	target, err := zipEntryTarget(base, "repo/robot.yaml")
+
 	must.Equal(nil, err)
-	must.Equal("/tmp/destination/repo/robot.yaml", target)
+	must.Equal(filepath.Join(base, "repo", "robot.yaml"), target)
 }
 
 func TestZipEntryTargetRejectsTraversalPath(t *testing.T) {
 	_, wont := hamlet.Specifications(t)
-	_, err := zipEntryTarget("/tmp/destination", "../../outside.txt")
+	base := t.TempDir()
+
+	_, err := zipEntryTarget(base, "../../outside.txt")
+
 	wont.Equal(nil, err)
 }

--- a/robot_tests/robot_bundle.robot
+++ b/robot_tests/robot_bundle.robot
@@ -6,6 +6,9 @@ Suite Setup  Bundle setup
 
 *** Keywords ***
 Bundle setup
+  Remove Directory    tmp/robocorp    True
+  Prepare Robocorp Home    tmp/robocorp
+  Fire And Forget   build/rcc ht init --revoke
   Fire And Forget   build/rcc ht delete 4e67cd8
   Create Bundle Files
 
@@ -100,9 +103,9 @@ Goal: Unpack missing bundle fails
   Use STDERR
   Must Have    does not exist
 
-Goal: Unpack path traversal bundle fails
-  Step    python3 -c "import zipfile; zf = zipfile.ZipFile('tmp/traversal_bundle.zip', 'w', zipfile.ZIP_DEFLATED); zf.writestr('../../outside.txt', 'owned'); zf.close()"
-  Step    build/rcc robot unpack --bundle tmp/traversal_bundle.zip --output tmp/unpack_test/traversal --force    1
+Goal: Unwrap path traversal zip fails
+  Create Traversal Bundle
+  Step    build/rcc robot unwrap --zipfile tmp/traversal_bundle.zip --directory tmp/unpack_test/traversal --force    1
   Use STDERR
   Must Have    invalid archive entry path
   Wont Exist    tmp/outside.txt

--- a/robot_tests/robot_bundle.robot
+++ b/robot_tests/robot_bundle.robot
@@ -100,6 +100,13 @@ Goal: Unpack missing bundle fails
   Use STDERR
   Must Have    does not exist
 
+Goal: Unpack path traversal bundle fails
+  Step    python3 -c "import zipfile; zf = zipfile.ZipFile('tmp/traversal_bundle.zip', 'w', zipfile.ZIP_DEFLATED); zf.writestr('../../outside.txt', 'owned'); zf.close()"
+  Step    build/rcc robot unpack --bundle tmp/traversal_bundle.zip --output tmp/unpack_test/traversal --force    1
+  Use STDERR
+  Must Have    invalid archive entry path
+  Wont Exist    tmp/outside.txt
+
 Goal: Cleanup
-  Fire And Forget    rm -f tmp/robot_bundle.zip tmp/robot_sfx.py tmp/robot_sfx.exe tmp/rcc_created_bundle.py
+  Fire And Forget    rm -f tmp/robot_bundle.zip tmp/robot_sfx.py tmp/robot_sfx.exe tmp/rcc_created_bundle.py tmp/traversal_bundle.zip tmp/outside.txt
   Remove Directory  tmp/unpack_test  True

--- a/robot_tests/supporting.py
+++ b/robot_tests/supporting.py
@@ -1,11 +1,36 @@
 import json
 import logging
+import os
 import re
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 log = logging.getLogger(__name__)
+
+RCC_ACTIVATION_ENV = {
+    "CONDA_BACKUP_GOROOT",
+    "CONDA_DEFAULT_ENV",
+    "CONDA_PREFIX",
+    "CONDA_PROMPT_MODIFIER",
+    "CONDA_SHLVL",
+    "GOROOT",
+    "MAMBA_ROOT_PREFIX",
+    "PYTHON_EXE",
+    "PYTHONDONTWRITEBYTECODE",
+    "PYTHONEXECUTABLE",
+    "PYTHONHOME",
+    "PYTHONNOUSERSITE",
+    "PYTHONPYCACHEPREFIX",
+    "PYTHONSTARTUP",
+    "RCC_ENVIRONMENT_HASH",
+    "RCC_EXE",
+    "RCC_HOLOTREE_SPACE_ROOT",
+    "RCC_INSTALLATION_ID",
+    "RCC_TRACKING_ALLOWED",
+    "RCC_VERSION",
+}
 
 
 def fix_command(command):
@@ -15,9 +40,21 @@ def fix_command(command):
     return command
 
 
-def get_cwd():
-    import os
+def clean_rcc_subprocess_env(command: str, env: dict[str, str] | None):
+    if env is not None:
+        return env
 
+    command = command.strip()
+    if not (command.startswith("build/rcc") or command.startswith(".\\build\\rcc.exe")):
+        return None
+
+    clean_env = os.environ.copy()
+    for key in RCC_ACTIVATION_ENV:
+        clean_env.pop(key, None)
+    return clean_env
+
+
+def get_cwd():
     cwd = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     detail = (
         "(rcc doesn't seem to be built, please run `inv local` before running tests)"
@@ -66,6 +103,7 @@ def run_and_return_code_output_error(
     stdin_contents: str | None = None,
 ) -> tuple[int, str, str]:
     command = fix_command(command)
+    env = clean_rcc_subprocess_env(command, env)
     cwd = get_cwd() if cwd is None else cwd
     log_command(command, cwd)
 
@@ -96,6 +134,22 @@ def parse_json(content):
 
 def is_windows() -> bool:
     return sys.platform == "win32"
+
+
+def create_traversal_bundle(
+    source: str = "robot_tests/testdata/robot_bundle",
+    target: str = "tmp/traversal_bundle.zip",
+):
+    root = Path(get_cwd())
+    source_root = root / source
+    target_path = root / target
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(target_path, "w", zipfile.ZIP_DEFLATED) as bundle:
+        for path in source_root.rglob("*"):
+            if path.is_file():
+                bundle.write(path, path.relative_to(source_root).as_posix())
+        bundle.writestr("../../outside.txt", "owned")
 
 
 def extract_env_value(output: str, key: str) -> str:

--- a/tasks.py
+++ b/tasks.py
@@ -88,6 +88,7 @@ def micromamba(c):
     """Download micromamba files from official conda-forge source"""
     import gzip
     import tempfile
+    import tarfile
 
     with open("assets/micromamba_version.txt", "r", encoding="utf-8") as f:
         version = f.read().strip()
@@ -100,8 +101,16 @@ def micromamba(c):
         "windows64": "windows_amd64",
     }
 
-    # Use a cross-platform temporary directory
-    tmp_dir = tempfile.gettempdir()
+    def _validate_archive_members(tar):
+        for member in tar.getmembers():
+            member_path = member.name
+            if os.path.isabs(member_path):
+                raise ValueError(f"Unsafe absolute path in archive: {member_path}")
+            normalized = os.path.normpath(member_path)
+            if normalized.startswith("..") or os.path.isabs(normalized):
+                raise ValueError(f"Unsafe path traversal in archive: {member_path}")
+            if member.issym() or member.islnk():
+                raise ValueError(f"Unsafe link entry in archive: {member_path}")
 
     for platform, arch in platforms.items():
         output = f"blobs/assets/micromamba.{arch}"
@@ -113,9 +122,8 @@ def micromamba(c):
         url = get_official_micromamba_url(version, platform)
         print(f"Downloading from official source: {url}")
 
-        # Create extraction directory
-        extract_dir = os.path.join(tmp_dir, "rcc_micromamba_extract")
-        os.makedirs(extract_dir, exist_ok=True)
+        # Create unique extraction directory
+        extract_dir = tempfile.mkdtemp(prefix="rcc_micromamba_extract_")
 
         # Download the archive
         archive_path = os.path.join(extract_dir, "micromamba.tar.bz2")
@@ -123,8 +131,8 @@ def micromamba(c):
 
         # Extract the binary from the archive
         # The archive contains Library/bin/micromamba.exe on Windows, bin/micromamba on Unix
-        import tarfile
         with tarfile.open(archive_path, "r:bz2") as tar:
+            _validate_archive_members(tar)
             tar.extractall(path=extract_dir)
 
         # Find and move the binary


### PR DESCRIPTION
## Summary

Groups the Codex Security hardening PRs opened for this release window into one stacked branch.

- hardens zip/template extraction against absolute paths and path traversal
- validates micromamba tar members before extraction, including symlink and hard-link escapes
- tightens release workflow behavior around tag-triggered releases, pinned actions, version validation, and no destructive release deletion
- updates release workflow docs and the v18.17.4 changelog entry
- adds Dagger RCC runner helpers and Robot coverage for malicious zip unwrap behavior
- fixes Robot bundle tests so nested RCC invocations do not overwrite the parent toolkit holotree environment

Included source PRs: #89, #90, #91, #92, #93, #94, #95, #96.

## Validation

- `git diff --check main..HEAD`
- workflow YAML parse via `yq e`
- `yamllint` on release workflows
- `dagger functions`
- `dagger call rcc --c version`
- `python3 -m py_compile tasks.py robot_tests/supporting.py`
- `docker run --rm -v "$PWD":/src -w /src -e GOARCH=amd64 -e CGO_ENABLED=0 golang:1.25.7 go test ./operations`
- `docker run --rm -v "$PWD":/src -w /src -e GOARCH=amd64 -e CGO_ENABLED=0 golang:1.25.7 go test ./...`
- `rcc run -r developer/toolkit.yaml --dev -t unitTests`
- `rcc run -r developer/toolkit.yaml --dev -t unpackTest`

## Release Gate

Keep this draft until the full required robot run has passed on each release target/device class. Do not create the v18.17.4 release tag from this branch until those checks are green.