### PR TITLE
chore(release): bump RCC to v18.17.7

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -1,5 +1,5 @@
 package common
 
 const (
-	Version = `v18.17.6`
+	Version = `v18.17.7`
 )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
 # rcc change log
 ## Unreleased
 
+## v18.17.7 (date: 12.07.2026)
+
 ### Dependency Updates
 
 - update the official Go toolchain from 1.26.3 to 1.26.5 across `go.mod`,


### PR DESCRIPTION
## Summary

- bump RCC from v18.17.6 to v18.17.7 in `common/version.go`
- promote the merged dependency-stack notes from Unreleased to the dated v18.17.7 changelog section

This releases the dependency and maintenance work merged through #112.

## Verification

- `git diff --check`
- `rcc run -r developer/toolkit.yaml --dev -t unitTests`
- `rcc run -r developer/toolkit.yaml --dev -t local`
- built `./build/rcc version` reports v18.17.7

## Release

After this PR merges and required CI passes, dispatch `create-release-tag.yml`
from `main`. The resulting v18.17.7 tag push builds the release artifacts and
publishes the GitHub release.
