### PR TITLE
fix(robot): harden bundle creation and unpacking

### DIFF
--- a/cmd/bundle_utils.go
+++ b/cmd/bundle_utils.go
@@ -173,8 +173,13 @@ func unpackRobotTree(zr *zip.Reader, dest string, force bool) error {
 	if err := os.MkdirAll(parent, 0o755); err != nil {
 		return err
 	}
-	if _, err := os.Lstat(absDest); err == nil && !force {
-		return fmt.Errorf("output directory %q already exists; use --force to overwrite", dest)
+	if info, err := os.Lstat(absDest); err == nil {
+		if !info.IsDir() && info.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("output path %q exists but is not a directory", dest)
+		}
+		if !force {
+			return fmt.Errorf("output directory %q already exists; use --force to overwrite", dest)
+		}
 	} else if err != nil && !os.IsNotExist(err) {
 		return err
 	}

--- a/cmd/bundle_utils.go
+++ b/cmd/bundle_utils.go
@@ -5,9 +5,111 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
+
+func safeBundleTarget(dest, name string) (string, error) {
+	if strings.Contains(name, `\`) {
+		return "", fmt.Errorf("zip entry path %q contains a non-portable path separator", name)
+	}
+	cleanName := path.Clean(name)
+	if cleanName == "." || path.IsAbs(cleanName) || cleanName == ".." || strings.HasPrefix(cleanName, "../") {
+		return "", fmt.Errorf("zip entry path %q is unsafe", name)
+	}
+
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return "", err
+	}
+	target := filepath.Join(absDest, filepath.FromSlash(cleanName))
+	rel, err := filepath.Rel(absDest, target)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("zip entry path %q would be extracted outside the destination directory", name)
+	}
+	return target, nil
+}
+
+func ensureSafeBundleParents(dest, target string) error {
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+	relParent, err := filepath.Rel(absDest, filepath.Dir(target))
+	if err != nil {
+		return err
+	}
+
+	current := absDest
+	if relParent == "." {
+		return nil
+	}
+	for _, component := range strings.Split(relParent, string(os.PathSeparator)) {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		switch {
+		case err == nil && info.Mode()&os.ModeSymlink != 0:
+			return fmt.Errorf("refusing to extract through symbolic link %q", current)
+		case err == nil && !info.IsDir():
+			return fmt.Errorf("refusing to extract through non-directory %q", current)
+		case err == nil:
+			continue
+		case os.IsNotExist(err):
+			if err := os.Mkdir(current, 0o755); err != nil {
+				return err
+			}
+		default:
+			return err
+		}
+	}
+	return nil
+}
+
+func writeBundleFile(f *zip.File, dest string) error {
+	if f.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to extract symbolic link %q", f.Name)
+	}
+	if !f.Mode().IsRegular() {
+		return fmt.Errorf("refusing to extract non-regular file %q", f.Name)
+	}
+
+	target, err := safeBundleTarget(dest, strings.TrimPrefix(filepath.ToSlash(f.Name), "robot/"))
+	if err != nil {
+		return err
+	}
+	if err := ensureSafeBundleParents(dest, target); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(target); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to replace symbolic link %q", target)
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	rc, err := f.Open()
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o666)
+	if err != nil {
+		_ = rc.Close()
+		return err
+	}
+	if _, err := io.Copy(out, rc); err != nil {
+		_ = out.Close()
+		_ = rc.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = rc.Close()
+		return err
+	}
+	return rc.Close()
+}
 
 // extractRobotTree extracts all files under the 'robot/' directory from the zip archive
 // represented by zr to the destination path dest. It returns an error if no 'robot/' directory
@@ -19,53 +121,84 @@ func extractRobotTree(zr *zip.Reader, dest string) error {
 		if strings.HasPrefix(name, "robot/") {
 			found = true
 			relPath := strings.TrimPrefix(name, "robot/")
-			if relPath == "" || strings.HasSuffix(relPath, "/") {
+			if relPath == "" {
 				continue
 			}
-
-			targetPath := filepath.Join(dest, relPath)
-			cleanTargetPath := filepath.Clean(targetPath)
-			absDest, err := filepath.Abs(dest)
-			if err != nil {
-				return err
+			if f.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to extract symbolic link %q", f.Name)
 			}
-			absTarget, err := filepath.Abs(cleanTargetPath)
-			if err != nil {
-				return err
+			if strings.HasSuffix(relPath, "/") {
+				if _, err := safeBundleTarget(dest, strings.TrimSuffix(relPath, "/")); err != nil {
+					return err
+				}
+				continue
 			}
-			rel, err := filepath.Rel(absDest, absTarget)
-			if err != nil {
-				return err
-			}
-			if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
-				return fmt.Errorf("zip entry %q would be extracted outside the destination directory", f.Name)
-			}
-
-			if err := os.MkdirAll(filepath.Dir(cleanTargetPath), 0755); err != nil {
-				return err
-			}
-
-			rc, err := f.Open()
-			if err != nil {
-				return err
-			}
-
-			out, err := os.Create(cleanTargetPath)
-			if err != nil {
-				rc.Close()
-				return err
-			}
-
-			_, err = io.Copy(out, rc)
-			out.Close()
-			rc.Close()
-			if err != nil {
+			if err := writeBundleFile(f, dest); err != nil {
 				return err
 			}
 		}
 	}
 	if !found {
 		return fmt.Errorf("no robot/ directory found in bundle")
+	}
+	return nil
+}
+
+// unpackRobotTree stages extraction beside dest and only replaces dest after the
+// complete robot tree has been validated and written successfully.
+func unpackRobotTree(zr *zip.Reader, dest string, force bool) error {
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(absDest)
+	if parent == absDest {
+		return fmt.Errorf("refusing to unpack over filesystem root %q", dest)
+	}
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	if _, err := os.Lstat(absDest); err == nil && !force {
+		return fmt.Errorf("output directory %q already exists; use --force to overwrite", dest)
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	stage, err := os.MkdirTemp(parent, "."+filepath.Base(absDest)+".unpack-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(stage)
+	if err := extractRobotTree(zr, stage); err != nil {
+		return err
+	}
+
+	if _, err := os.Lstat(absDest); os.IsNotExist(err) {
+		return os.Rename(stage, absDest)
+	} else if err != nil {
+		return err
+	} else if !force {
+		return fmt.Errorf("output directory %q already exists; use --force to overwrite", dest)
+	}
+
+	backup, err := os.MkdirTemp(parent, "."+filepath.Base(absDest)+".previous-")
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(backup); err != nil {
+		return err
+	}
+	if err := os.Rename(absDest, backup); err != nil {
+		return err
+	}
+	if err := os.Rename(stage, absDest); err != nil {
+		if rollbackErr := os.Rename(backup, absDest); rollbackErr != nil {
+			return fmt.Errorf("replace destination: %w (rollback failed: %v)", err, rollbackErr)
+		}
+		return err
+	}
+	if err := os.RemoveAll(backup); err != nil {
+		return fmt.Errorf("remove previous destination %q: %w", backup, err)
 	}
 	return nil
 }

--- a/cmd/bundle_utils.go
+++ b/cmd/bundle_utils.go
@@ -115,6 +115,21 @@ func writeBundleFile(f *zip.File, dest string) error {
 // represented by zr to the destination path dest. It returns an error if no 'robot/' directory
 // is found in the archive.
 func extractRobotTree(zr *zip.Reader, dest string) error {
+	info, err := os.Lstat(dest)
+	switch {
+	case err == nil && info.Mode()&os.ModeSymlink != 0:
+		return fmt.Errorf("refusing to extract into symbolic link %q", dest)
+	case err == nil && !info.IsDir():
+		return fmt.Errorf("refusing to extract into non-directory %q", dest)
+	case err == nil:
+	case os.IsNotExist(err):
+		if err := os.Mkdir(dest, 0o755); err != nil {
+			return err
+		}
+	default:
+		return err
+	}
+
 	found := false
 	for _, f := range zr.File {
 		name := filepath.ToSlash(f.Name)

--- a/cmd/bundle_utils_test.go
+++ b/cmd/bundle_utils_test.go
@@ -107,6 +107,25 @@ func TestUnpackRobotTreeForceReplacesDestination(t *testing.T) {
 	}
 }
 
+func TestUnpackRobotTreeForceRejectsFileDestination(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "robot")
+	if err := os.WriteFile(dest, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := unpackRobotTree(testZipReader(t, map[string]string{
+		"robot/current.txt": "current",
+	}), dest, true)
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("expected non-directory rejection, got %v", err)
+	}
+	contents, readErr := os.ReadFile(dest)
+	if readErr != nil || string(contents) != "keep" {
+		t.Fatalf("existing file was modified: contents=%q err=%v", contents, readErr)
+	}
+}
+
 func TestUnpackRobotTreeFailurePreservesDestination(t *testing.T) {
 	parent := t.TempDir()
 	dest := filepath.Join(parent, "robot")

--- a/cmd/bundle_utils_test.go
+++ b/cmd/bundle_utils_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testZipReader(t *testing.T, files map[string]string) *zip.Reader {
+	t.Helper()
+
+	var payload bytes.Buffer
+	zw := zip.NewWriter(&payload)
+	for name, contents := range files {
+		entry, err := zw.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := entry.Write([]byte(contents)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(payload.Bytes()), int64(payload.Len()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return zr
+}
+
+func TestExtractRobotTreeRejectsSymlinkComponent(t *testing.T) {
+	dest := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(dest, "linked")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	err := extractRobotTree(testZipReader(t, map[string]string{
+		"robot/linked/escaped.txt": "must stay contained",
+	}), dest)
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("expected symbolic-link rejection, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "escaped.txt")); !os.IsNotExist(err) {
+		t.Fatalf("archive wrote through destination symlink: %v", err)
+	}
+}
+
+func TestUnpackRobotTreeForceReplacesDestination(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "robot")
+	outside := t.TempDir()
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "stale.txt"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dest, "linked")); err != nil {
+		t.Skipf("symlinks are unavailable: %v", err)
+	}
+
+	err := unpackRobotTree(testZipReader(t, map[string]string{
+		"robot/current.txt":          "current",
+		"robot/linked/contained.txt": "contained",
+	}), dest, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatalf("force unpack merged with the old destination: %v", err)
+	}
+	contents, err := os.ReadFile(filepath.Join(dest, "current.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "current" {
+		t.Fatalf("unexpected extracted contents %q", contents)
+	}
+	if _, err := os.Stat(filepath.Join(outside, "contained.txt")); !os.IsNotExist(err) {
+		t.Fatalf("force unpack followed the old destination symlink: %v", err)
+	}
+	contents, err = os.ReadFile(filepath.Join(dest, "linked", "contained.txt"))
+	if err != nil || string(contents) != "contained" {
+		t.Fatalf("staged file missing: contents=%q err=%v", contents, err)
+	}
+}
+
+func TestUnpackRobotTreeFailurePreservesDestination(t *testing.T) {
+	parent := t.TempDir()
+	dest := filepath.Join(parent, "robot")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "keep.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := unpackRobotTree(testZipReader(t, map[string]string{
+		"robot/../../escaped.txt": "unsafe",
+	}), dest, true)
+	if err == nil {
+		t.Fatal("expected unsafe path to fail")
+	}
+	contents, readErr := os.ReadFile(filepath.Join(dest, "keep.txt"))
+	if readErr != nil || string(contents) != "keep" {
+		t.Fatalf("failed unpack changed the old destination: contents=%q err=%v", contents, readErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(parent, "escaped.txt")); !os.IsNotExist(statErr) {
+		t.Fatalf("unsafe archive wrote outside the destination: %v", statErr)
+	}
+}

--- a/cmd/bundle_utils_test.go
+++ b/cmd/bundle_utils_test.go
@@ -52,6 +52,21 @@ func TestExtractRobotTreeRejectsSymlinkComponent(t *testing.T) {
 	}
 }
 
+func TestExtractRobotTreeCreatesDestination(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "workarea")
+
+	err := extractRobotTree(testZipReader(t, map[string]string{
+		"robot/task.py": "print('ok')",
+	}), dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(filepath.Join(dest, "task.py"))
+	if err != nil || string(contents) != "print('ok')" {
+		t.Fatalf("extracted file missing: contents=%q err=%v", contents, err)
+	}
+}
+
 func TestUnpackRobotTreeForceReplacesDestination(t *testing.T) {
 	parent := t.TempDir()
 	dest := filepath.Join(parent, "robot")

--- a/cmd/robotBundle.go
+++ b/cmd/robotBundle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/joshyorko/rcc/operations"
 	"github.com/joshyorko/rcc/pathlib"
 	"github.com/joshyorko/rcc/pretty"
+	"github.com/joshyorko/rcc/robot"
 	"github.com/spf13/cobra"
 )
 
@@ -24,9 +25,14 @@ var (
 var bundleCmd = &cobra.Command{
 	Use:   "bundle",
 	Short: "Create a self-contained robot bundle.",
-	Long: `Create a self-contained robot bundle that includes the robot code and the
-environment (hololib). The output is an executable Python script that can be
-executed by 'rcc robot run-from-bundle'.`,
+	Long: `Create a robot bundle containing project files and an exported Holotree environment.
+
+Project files excluded by robot.yaml ignoreFiles are omitted. Project symlinks are
+rejected because their targets are outside the bundle's portable trust boundary.
+The output is replaced atomically only after the complete bundle is written.
+
+The generated Python file is a ZIP-compatible launcher that prints instructions;
+run the robot with 'rcc robot run-from-bundle'. It is not an RCC carrier executable.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if common.DebugFlag() {
 			defer common.Stopwatch("Bundle creation lasted").Report()
@@ -53,7 +59,13 @@ executed by 'rcc robot run-from-bundle'.`,
 		pretty.Guard(err == nil, 3, "Failed to create environment: %v", err)
 
 		// 2. Export holotree
-		tempHololib := filepath.Join(os.TempDir(), fmt.Sprintf("hololib_%s.zip", hash))
+		temp, err := os.CreateTemp("", fmt.Sprintf("rcc-hololib-%s-*.zip", hash))
+		pretty.Guard(err == nil, 6, "Failed to reserve temporary hololib file: %v", err)
+		tempHololib := temp.Name()
+		err = temp.Close()
+		pretty.Guard(err == nil, 6, "Failed to close temporary hololib file: %v", err)
+		err = os.Remove(tempHololib)
+		pretty.Guard(err == nil, 6, "Failed to prepare temporary hololib path: %v", err)
 		defer os.Remove(tempHololib)
 
 		common.Log("Exporting holotree to %s...", tempHololib)
@@ -90,12 +102,31 @@ func init() {
 }
 
 func createBundle(robotYamlPath, hololibPath, outputPath, condaConfigPath string) error {
-	// Create output file
-	out, err := os.Create(outputPath)
+	config, err := robot.LoadRobotYaml(robotYamlPath, false)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	ignored, err := pathlib.LoadIgnoreFiles(config.IgnoreFiles())
+	if err != nil {
+		return err
+	}
+
+	absOutputPath, err := filepath.Abs(outputPath)
+	if err != nil {
+		return err
+	}
+	out, err := os.CreateTemp(filepath.Dir(absOutputPath), "."+filepath.Base(absOutputPath)+"-*.tmp")
+	if err != nil {
+		return err
+	}
+	tempOutputPath := out.Name()
+	committed := false
+	defer func() {
+		if !committed {
+			out.Close()
+			os.Remove(tempOutputPath)
+		}
+	}()
 
 	// Make it executable
 	if err := out.Chmod(0755); err != nil {
@@ -128,16 +159,10 @@ if __name__ == "__main__":
 
 	// Create zip writer
 	zw := zip.NewWriter(out)
-	defer zw.Close()
 
 	// Add robot files
 	baseDir := filepath.Dir(robotYamlPath)
-
-	// Get absolute path of output to avoid skipping wrong files
-	absOutputPath, err := filepath.Abs(outputPath)
-	if err != nil {
-		return err
-	}
+	defaults := operations.DefaultIgnores(absOutputPath)
 
 	err = filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -149,25 +174,23 @@ if __name__ == "__main__":
 			return err
 		}
 
-		// Ignore output directory and .git, etc.
-		// Also ignore the bundle itself if it's being created inside the directory
 		absPath, err := filepath.Abs(path)
 		if err != nil {
 			return err
 		}
-		if absPath == absOutputPath {
+		if absPath == absOutputPath || absPath == tempOutputPath {
 			return nil
 		}
 
-		if strings.HasPrefix(relPath, "output") || strings.HasPrefix(relPath, ".git") || strings.HasPrefix(relPath, ".") {
-			if info.IsDir() && relPath != "." {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("project path %q is a symbolic link", relPath)
+		}
+		if relPath != "." && (defaults(info) || ignored(info)) {
+			if info.IsDir() {
 				return filepath.SkipDir
 			}
-			if relPath != "." {
-				return nil
-			}
+			return nil
 		}
-
 		if info.IsDir() {
 			return nil
 		}
@@ -182,14 +205,7 @@ if __name__ == "__main__":
 			return err
 		}
 
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		_, err = io.Copy(w, f)
-		return err
+		return copyBundleFile(w, path)
 	})
 	if err != nil {
 		return err
@@ -201,13 +217,7 @@ if __name__ == "__main__":
 		if err != nil {
 			return err
 		}
-		f, err := os.Open(condaConfigPath)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		_, err = io.Copy(w, f)
-		if err != nil {
+		if err := copyBundleFile(w, condaConfigPath); err != nil {
 			return err
 		}
 	}
@@ -217,12 +227,31 @@ if __name__ == "__main__":
 	if err != nil {
 		return err
 	}
-	f, err := os.Open(hololibPath)
+	if err := copyBundleFile(w, hololibPath); err != nil {
+		return err
+	}
+	if err := zw.Close(); err != nil {
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempOutputPath, absOutputPath); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func copyBundleFile(target io.Writer, sourcePath string) error {
+	source, err := os.Open(sourcePath)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	_, err = io.Copy(w, f)
-
-	return err
+	_, copyErr := io.Copy(target, source)
+	closeErr := source.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
 }

--- a/cmd/robotBundleUnpack.go
+++ b/cmd/robotBundleUnpack.go
@@ -18,8 +18,12 @@ var (
 var unpackCmd = &cobra.Command{
 	Use:   "unpack",
 	Short: "Unpack a robot bundle into a directory.",
-	Long: `Unpack a robot bundle into a directory. This command extracts the robot code
-from the bundle into the specified directory.`,
+	Long: `Unpack the robot/ tree from a robot bundle into a new directory.
+
+Bundle contents are untrusted input: unsafe archive paths and symlinks are rejected.
+The destination must not exist unless --force is used. With --force, extraction is
+staged beside the destination and replaces the complete destination; existing files
+are not merged or preserved.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if common.DebugFlag() {
 			defer common.Stopwatch("Bundle unpack lasted").Report()
@@ -50,7 +54,7 @@ from the bundle into the specified directory.`,
 		defer zr.Close()
 
 		// Extract robot tree
-		err = extractRobotTree(&zr.Reader, unpackOutput)
+		err = unpackRobotTree(&zr.Reader, unpackOutput, unpackForce)
 		if err != nil {
 			pretty.Exit(3, "Failed to unpack bundle: %v", err)
 		}
@@ -63,7 +67,7 @@ func init() {
 	robotCmd.AddCommand(unpackCmd)
 	unpackCmd.Flags().StringVarP(&unpackBundle, "bundle", "b", "", "Path to the bundle file.")
 	unpackCmd.Flags().StringVarP(&unpackOutput, "output", "o", "", "Output directory.")
-	unpackCmd.Flags().BoolVarP(&unpackForce, "force", "f", false, "Overwrite existing directory.")
+	unpackCmd.Flags().BoolVarP(&unpackForce, "force", "f", false, "Atomically replace the complete existing destination directory.")
 	unpackCmd.MarkFlagRequired("bundle")
 	unpackCmd.MarkFlagRequired("output")
 }

--- a/cmd/robotBundle_test.go
+++ b/cmd/robotBundle_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeBundleFixture(t *testing.T, root string) (string, string, string) {
+	t.Helper()
+	robotYaml := filepath.Join(root, "robot.yaml")
+	hololib := filepath.Join(t.TempDir(), "hololib.zip")
+	conda := filepath.Join(root, "conda.yaml")
+	for path, body := range map[string]string{
+		robotYaml:                           "tasks:\n  test:\n    command:\n      - python\n      - task.py\ncondaConfigFile: conda.yaml\nignoreFiles:\n  - .robotignore\n",
+		filepath.Join(root, ".robotignore"): "ignored.txt\nlinked.py\n",
+		filepath.Join(root, "task.py"):      "print('included')\n",
+		filepath.Join(root, "ignored.txt"):  "secret\n",
+		conda:                               "channels: []\n",
+		hololib:                             "hololib",
+	} {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return robotYaml, hololib, conda
+}
+
+func bundleEntries(t *testing.T, filename string) map[string]bool {
+	t.Helper()
+	zr, err := zip.OpenReader(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	result := make(map[string]bool, len(zr.File))
+	for _, entry := range zr.File {
+		result[entry.Name] = true
+	}
+	return result
+}
+
+func TestCreateBundleUsesRobotIgnoreFiles(t *testing.T) {
+	root := t.TempDir()
+	robotYaml, hololib, conda := writeBundleFixture(t, root)
+	output := filepath.Join(t.TempDir(), "bundle.py")
+
+	if err := createBundle(robotYaml, hololib, output, conda); err != nil {
+		t.Fatal(err)
+	}
+	entries := bundleEntries(t, output)
+	if !entries["robot/task.py"] || !entries["robot/robot.yaml"] {
+		t.Fatalf("expected project files in bundle, got %v", entries)
+	}
+	if entries["robot/ignored.txt"] {
+		t.Fatal("robot.yaml ignoreFiles entry was included")
+	}
+}
+
+func TestCreateBundleRejectsProjectSymlinkAndPreservesOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation requires additional privileges on Windows")
+	}
+	root := t.TempDir()
+	robotYaml, hololib, conda := writeBundleFixture(t, root)
+	if err := os.Symlink(filepath.Join(root, "task.py"), filepath.Join(root, "linked.py")); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(t.TempDir(), "bundle.py")
+	if err := os.WriteFile(output, []byte("previous bundle"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := createBundle(robotYaml, hololib, output, conda)
+	if err == nil || !strings.Contains(err.Error(), "symbolic link") {
+		t.Fatalf("expected symbolic link rejection, got %v", err)
+	}
+	content, readErr := os.ReadFile(output)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(content) != "previous bundle" {
+		t.Fatalf("failed creation replaced output with %q", content)
+	}
+}
+
+func TestCreateBundleAtomicallyReplacesExistingOutput(t *testing.T) {
+	root := t.TempDir()
+	robotYaml, hololib, conda := writeBundleFixture(t, root)
+	output := filepath.Join(t.TempDir(), "bundle.py")
+	if err := os.WriteFile(output, []byte("previous bundle"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := createBundle(robotYaml, hololib, output, conda); err != nil {
+		t.Fatal(err)
+	}
+	entries := bundleEntries(t, output)
+	if !entries["hololib/hololib.zip"] || !entries["envs/default/conda.yaml"] {
+		t.Fatalf("replacement bundle missing payload entries: %v", entries)
+	}
+	info, err := os.Stat(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("replacement bundle is not executable: %v", info.Mode())
+	}
+}

--- a/cmd/robotRunFromBundle.go
+++ b/cmd/robotRunFromBundle.go
@@ -22,7 +22,13 @@ var robotRunFromBundleCmd = &cobra.Command{
 
 This command extracts the robot/ tree from the bundle to a temporary
 workarea, builds any environments found in envs/, and runs the
-specified task.`,
+specified task. Treat bundles as untrusted input and obtain them only
+from sources you trust.
+
+Importing and restoring the bundled Holotree environment writes persistent cache
+and catalog state below ROBOCORP_HOME. A bundle can avoid package downloads only
+when it contains every required artifact and the target OS and architecture are
+compatible with the exported environment; it does not include RCC itself.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		bundleFile := args[0]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,20 @@
 # rcc change log
 ## Unreleased
 
+### Security
+
+- harden robot bundles against filesystem boundary escapes
+  - stage `robot unpack` extraction and replace the complete destination for
+    `--force` instead of following pre-existing symlinks during a merge
+  - reject unsafe archive paths, archive symlinks, and project symlinks
+  - apply `robot.yaml` `ignoreFiles` consistently during bundle creation
+
+### Reliability
+
+- create robot bundle outputs and temporary Holotree exports with unique
+  temporary files, publish completed outputs atomically, and propagate file
+  and archive finalization errors
+
 ## v18.18.0 (date: 28.07.2026)
 
 ### New Features

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,8 @@
 - create robot bundle outputs and temporary Holotree exports with unique
   temporary files, publish completed outputs atomically, and propagate file
   and archive finalization errors
+- preserve `run-from-bundle` extraction into a newly created temporary
+  workarea while enforcing the hardened destination checks
 
 ## v18.18.0 (date: 28.07.2026)
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1000,7 +1000,7 @@ of "profile" that developers can use to setup all of required configurations.
 
 ## How to create and run a self-contained bundle?
 
-Starting from rcc v18.9.0, you can create self-contained robot bundles that include both your robot code and the required environment (Holotree). These bundles are single-file executables (Python zipapps) that can be easily distributed and run on other machines.
+Starting from rcc v18.9.0, you can create robot bundles that include robot code and an exported Holotree environment. A bundle is a ZIP-compatible Python launcher, not an RCC carrier executable and not a replacement for the `rcc` binary on the target machine.
 
 ### Creating a bundle
 
@@ -1014,7 +1014,12 @@ rcc robot bundle --robot robot.yaml --output my-robot.py
 This command will:
 1. Build the environment defined in `robot.yaml` (if not already built).
 2. Export the environment from Holotree.
-3. Package the robot code and the exported environment into a single Python script.
+3. Package non-ignored robot files and the exported environment into a single Python script.
+
+`ignoreFiles` entries from `robot.yaml` use the same ignore machinery as `rcc wrap`.
+Project symlinks are rejected instead of followed; replace them with regular project
+files before bundling. The output path is atomically replaced only after a complete
+bundle has been written, so an existing bundle remains intact if creation fails.
 
 ### Running a bundle
 
@@ -1032,11 +1037,28 @@ You can also execute the bundle directly if it has the executable permission:
 ```
 (Note: Direct execution prints instructions on how to run it with `rcc`)
 
+To recover only the robot source tree, use `rcc robot unpack --bundle my-robot.py
+--output robot-source`. The destination must be absent. `--force` stages extraction
+and atomically replaces the whole destination rather than merging with it, so files
+that exist only in the old destination are removed. Archive paths and symlinks are
+validated during extraction, but bundles should still be treated as untrusted input.
+
 ### Benefits
 
 - **Single-file distribution**: Everything needed to run the robot is in one file.
-- **Air-gapped support**: The bundle contains the full environment, so no internet connection is needed to build it on the target machine.
+- **Offline operation when complete**: No package download is needed only when the bundle contains every required artifact and the target platform is compatible with the exported environment. RCC itself must already be installed.
 - **Version pinning**: The environment in the bundle is exactly what was built at creation time.
+
+Bundles are platform-specific environment snapshots. Do not assume a bundle exported
+on one operating system or CPU architecture will run on another. Running a bundle
+imports and restores Holotree content into persistent state below `ROBOCORP_HOME`;
+the temporary robot workarea is removed, but the environment cache and catalog remain.
+
+If an offline run attempts network access, verify that `hololib/hololib.zip` is
+present and complete, that all conda/pip artifacts were exported, and that the target
+platform matches the build platform. If environment import or restore fails, confirm
+that `ROBOCORP_HOME` is writable and has enough free space. If bundling reports a
+symlink, replace it with a regular file or directory inside the robot project.
 
 
 ## Where can I find updates for rcc?
@@ -1066,4 +1088,3 @@ rcc docs changelog
 Sure. See following URL.
 
 https://github.com/joshyorko/rcc/blob/master/docs/recipes.md
-

--- a/operations/zipper.go
+++ b/operations/zipper.go
@@ -363,7 +363,7 @@ func (it *zipper) Close() {
 	}
 }
 
-func defaultIgnores(selfie string) pathlib.Ignore {
+func DefaultIgnores(selfie string) pathlib.Ignore {
 	result := make([]pathlib.Ignore, 0, 10)
 	result = append(result, pathlib.IgnorePattern(selfie))
 	result = append(result, pathlib.IgnorePattern(".git"))
@@ -467,7 +467,7 @@ func Zip(directory, zipfile string, ignores []string) error {
 	if err != nil {
 		return err
 	}
-	defaults := defaultIgnores(zipfile)
+	defaults := DefaultIgnores(zipfile)
 	pathlib.ForceWalk(directory, pathlib.ForceFilename("hololib.zip"), pathlib.CompositeIgnore(defaults, ignored), zipper.Add)
 	return nil
 }

--- a/robot_tests/robot_bundle.robot
+++ b/robot_tests/robot_bundle.robot
@@ -112,6 +112,7 @@ Goal: Forced unpack does not follow destination symlinks
   Must Exist    tmp/unpack_test/symlink-force/task.py
   ${outside}=    Get File    tmp/outside.txt
   Should Be Equal    ${outside}    outside
+  Remove File    tmp/outside.txt
   Use STDERR
   Must Have    OK.
 

--- a/robot_tests/robot_bundle.robot
+++ b/robot_tests/robot_bundle.robot
@@ -93,8 +93,25 @@ Goal: Unpack to existing directory fails
 
 Goal: Unpack to existing directory with force succeeds
   Create Directory  tmp/unpack_test/force
+  Create File    tmp/unpack_test/force/stale.txt    stale
   Step    build/rcc robot unpack --bundle tmp/robot_bundle.zip --output tmp/unpack_test/force --force
   Must Exist    tmp/unpack_test/force/robot.yaml
+  Wont Exist    tmp/unpack_test/force/stale.txt
+  Use STDERR
+  Must Have    OK.
+
+Goal: Forced unpack does not follow destination symlinks
+  ${is_windows}=    Is Windows
+  IF    ${is_windows}
+    Skip    Symlink creation is not reliably available on Windows test hosts
+  END
+  Create Directory  tmp/unpack_test/symlink-force
+  Create File    tmp/outside.txt    outside
+  Step    ln -s ../../outside.txt tmp/unpack_test/symlink-force/task.py
+  Step    build/rcc robot unpack --bundle tmp/robot_bundle.zip --output tmp/unpack_test/symlink-force --force
+  Must Exist    tmp/unpack_test/symlink-force/task.py
+  ${outside}=    Get File    tmp/outside.txt
+  Should Be Equal    ${outside}    outside
   Use STDERR
   Must Have    OK.
 


### PR DESCRIPTION
## Summary

- stage robot bundle extraction beside the destination and replace the complete destination for `--force`
- reject traversal, archive symlinks, unsafe destination components, and project symlinks
- apply `robot.yaml` `ignoreFiles` and standard wrapping exclusions during bundle creation
- create bundle output and Holotree export temporaries safely, publish output atomically, and propagate finalization errors
- document bundle carrier behavior, trust boundaries, platform/offline limits, persistent `ROBOCORP_HOME` effects, and troubleshooting
- add focused Go coverage and a Robot CLI regression

## Root cause

Unpack wrote directly into an existing destination after lexical path validation, so a pre-existing symlink could redirect writes outside the tree. Bundle creation walked the project independently of wrapping's ignore configuration, allowed symlink inputs, and wrote directly to its final output.

## Verification

- `go test ./cmd -count=1`
- `go test ./operations -count=1`
- `git diff --check`
- `rcc run -r developer/toolkit.yaml --dev -t unitTests`
- `rcc run -r developer/toolkit.yaml --dev -t local`
- focused `robot_tests/robot_bundle.robot`: 16 passed, 0 failed
- `rcc run -r developer/toolkit.yaml -t robot`: 169 tests executed; 167 passed,
  1 skipped, and only `Development Process` failed because `common/version.go`
  is intentionally unchanged

The version-policy failure is explicitly waived for this PR because release versioning
is automatic. After test execution Robot Framework 6.1.1 also failed to generate HTML
with `ModuleNotFoundError: robot.htmldata.rebot`; a focused rerun with HTML disabled
confirmed the single test failure is the waived version check.

Platform exercised: Linux amd64. Windows and macOS replacement semantics remain
unverified; Go's overwrite behavior for `os.Rename` differs on Windows. Portable
forced directory replacement uses staged renames with rollback, leaving a brief
interval where the destination name is absent.

Fixes #116
